### PR TITLE
Remove; from OS import path, to simplify code

### DIFF
--- a/Shmup Adding Graphics Part 4/Shmup Adding Graphics Part 4 Completed.py
+++ b/Shmup Adding Graphics Part 4/Shmup Adding Graphics Part 4 Completed.py
@@ -1,8 +1,6 @@
 import pygame
 import random
-from os import path
 
-img_dir = path.join(path.dirname(__file__), 'images')
 
 pygame.init()
 
@@ -90,11 +88,11 @@ class Projectile(pygame.sprite.Sprite):
             self.kill()
 
 # Load all game graphics
-background = pygame.image.load(path.join(img_dir, 'background.png')).convert()
+background = pygame.image.load('images/background.png')
 background_rect = background.get_rect()
-player_img = pygame.image.load(path.join(img_dir, 'ship.png')).convert_alpha()
-mob_img = pygame.image.load(path.join(img_dir, 'meteor.png')).convert_alpha()
-laser_img = pygame.image.load(path.join(img_dir, 'laser.png')).convert_alpha()
+player_img = pygame.image.load('images/ship.png')
+mob_img = pygame.image.load('images/meteor.png')
+laser_img = pygame.image.load('images/laser.png')
 
 player = Player()
 all_sprites = pygame.sprite.Group()


### PR DESCRIPTION
As the image folder containing the assets is in the same directory we could consider using images/example.py to call the images? 
The advantage is that this simplifies the code however, it will mean the students will have to be more careful where they put their images. What do you think?